### PR TITLE
fix: Creating output directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 #Gradle folders
 .gradle
 build
+bin/
 
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/
@@ -28,3 +29,9 @@ build
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+# Direnv configuration
+.envrc
+
+# VSCode configuration
+.vscode/

--- a/bin/main/META-INF/gradle-plugins/dk.grixie.jinja2.properties
+++ b/bin/main/META-INF/gradle-plugins/dk.grixie.jinja2.properties
@@ -1,0 +1,1 @@
+implementation-class=dk.grixie.jinja2.gradle.plugin.Jinja2Plugin

--- a/src/test/java/dk/grixie/jinja2/io/EngineFileUtilityTest.java
+++ b/src/test/java/dk/grixie/jinja2/io/EngineFileUtilityTest.java
@@ -70,24 +70,28 @@ public class EngineFileUtilityTest {
     @Test
     public void testMakeNotNestedOutputDirectory() {
         File outputFile = new File("build/testCreateDeeplyNestedOutputDirectory");
+        File outputDirectory = outputFile.getParentFile();
+
         when(fileProvider.get()).thenReturn(outputFile);
         when(fileProperty.getAsFile()).thenReturn(fileProvider);
 
         EngineFileUtility engineFileUtility = new EngineFileUtility();
         engineFileUtility.makeParents(fileProperty);
 
-        assertThat(outputFile).exists();
+        assertThat(outputDirectory).exists();
     }
 
     @Test
     public void testMakeDeeplyNestedOutputDirectory() {
         File outputFile = new File("build/a/b/c/d/e/f/testCreateDeeplyNestedOutputDirectory");
+        File outputDirectory = outputFile.getParentFile();
+
         when(fileProvider.get()).thenReturn(outputFile);
         when(fileProperty.getAsFile()).thenReturn(fileProvider);
 
         EngineFileUtility engineFileUtility = new EngineFileUtility();
         engineFileUtility.makeParents(fileProperty);
 
-        assertThat(outputFile).exists();
+        assertThat(outputDirectory).exists();
     }
 }


### PR DESCRIPTION
The output directory must be created for the parent of the output file path. The fix now takes the parent of the output file and creates the parent directory with `File.mkdirs()`. In this is the equivalent of `mkdir -p dir`.

Fixes issue #2